### PR TITLE
Simplify code and add some template functions

### DIFF
--- a/includes/class-my-plugin-info.php
+++ b/includes/class-my-plugin-info.php
@@ -1,0 +1,116 @@
+<?php
+
+class DOT_MyPluginInfo {
+
+
+	/**
+	 * Constructor
+	 */
+	public function __construct() {	}
+
+	/**
+	 * Add hooks
+	 */
+	public function add_hooks() {
+		// Hook up to the init action
+		add_action( 'init', array( $this, 'init' ) );
+	}
+
+	/**
+	 * Runs when WordPress is initialized
+	 */
+	public function init() {
+		// Register the shortcode [mpi slug='my-plugin-info' field='version']
+		add_shortcode( 'mpi', array( $this, 'shortcode' ) );
+	}
+
+	/**
+	 * @param string $slug The WordPress.org slug of the plugin
+	 * @return StdClass
+	 */
+	public function get_plugin_info( $slug ) {
+
+		// Create a empty array with variable name different based on plugin slug
+		$transient_name = 'mpi' . $slug;
+
+		/**
+		 * Check if transient with the plugin data exists
+		 */
+		$info = get_transient( $transient_name );
+
+		if ( empty( $info ) ) {
+
+			/**
+			 * Connect to WordPress.org using plugins_api
+			 * About plugins_api -
+			 * http://wp.tutsplus.com/tutorials/plugins/communicating-with-the-wordpress-org-plugin-api/
+			 */
+			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			$info = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
+
+
+			// Check for errors with the data returned from WordPress.org
+			if ( ! $info or is_wp_error( $info ) ) {
+				return null;
+			}
+
+
+			// Set a transient with the plugin data
+			// Use Options API with auto update cron job in next version.
+			set_transient( $transient_name, $info, 1 * HOUR_IN_SECONDS );
+		}
+
+		return $info;
+	}
+
+	/**
+	 * Get a specific field
+	 *
+	 * @param string $slug The WordPress.org slug of the plugin
+	 * @param string $field The field you want to retrieve
+	 *
+	 * @return string
+	 */
+	public function get_plugin_field( $slug, $field ) {
+
+		// Fetch info
+		$info = $this->get_plugin_info( $slug );
+
+		if( ! is_object( $info ) || ! property_exists( $info, $field ) ) {
+			return '';
+		}
+
+		return $info->{$field};
+	}
+
+	/**
+	 * @param array $atts
+	 *
+	 * @return string
+	 */
+	public function shortcode( $atts = array() ) {
+
+		// get our variable from $atts
+		$atts = shortcode_atts( array(
+			'slug' => '', //foo is a default value
+			'field' => ''
+		), $atts );
+
+		/**
+		 * Slug & field must both be givens
+		 */
+		if ( '' === $atts['slug'] || '' === $atts['field'] ) {
+			return '';
+		}
+
+		// Sanitize slug attribute
+		$slug = sanitize_title( $atts['slug'] );
+
+		// Sanitize field attribute
+		$field = sanitize_title( $atts['field'] );
+
+		return $this->get_plugin_field( $slug, $field );
+	}
+
+
+}

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @param string $slug The WordPress.org slug of the plugin
+ *
+ * @return StdClass
+ */
+function mpi_get_plugin_info( $slug ) {
+	global $my_plugin_information;
+	return $my_plugin_information->get_plugin_info( $slug );
+}
+
+/**
+ * @param string $slug The WordPress.org slug of the plugin
+ * @param string $field
+ *
+ * @return string
+ */
+function mpi_get_plugin_field( $slug, $field ) {
+	global $my_plugin_information;
+	return $my_plugin_information->get_plugin_field( $slug, $field );
+}

--- a/my-plugin-info.php
+++ b/my-plugin-info.php
@@ -26,147 +26,16 @@ License:
 */
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-
-if ( ! class_exists( 'DOT_MyPluginInfo' ) ) {
-
-	class DOT_MyPluginInfo {
-
-
-		/**
-		 * Constructor
-		 */
-		public function __construct() {
-			//Hook up to the init action
-			add_action( 'init', array( $this, 'init' ) );
-		}
-
-		/**
-		 * Runs when the plugin is initialized
-		 */
-		public function init() {
-
-			// Register the shortcode [mpi slug='my-plugin-info' field='version']
-			add_shortcode( 'mpi', array( $this, 'output' ) );
-		}
-
-
-		public function output( $atts = array() ) {
-
-			// get our variable from $atts
-			$atts = shortcode_atts( array(
-				'slug' => '', //foo is a default value
-				'field' => ''
-				), $atts );
-
-			/**
-			 * Slug & field must both be givens
-			 */
-			if ( '' === $atts['slug'] || '' === $atts['field'] ) {
-				return false;
-			}
-
-			// Sanitize slug attribute
-			$slug = sanitize_title( $atts['slug'] );
-
-			// Create a empty array with variable name different based on plugin slug
-			$transient_name = 'mpi' . $slug;
-
-			/**
-			 * Check if transient with the plugin data exists
-			 */
-			$info = get_transient( $transient_name );
-
-			if ( empty( $info ) ) {
-
-				/**
-				 * Connect to WordPress.org using plugins_api
-				 * About plugins_api -
-				 * http://wp.tutsplus.com/tutorials/plugins/communicating-with-the-wordpress-org-plugin-api/
-				 */
-				require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-				$info = plugins_api( 'plugin_information', array( 'slug' => $slug ) );
-
-
-				// Check for errors with the data returned from WordPress.org
-				if ( ! $info or is_wp_error( $info ) ) {
-					return false;
-				}
-
-
-				// Set a transient with the plugin data
-				// Use Options API with auto update cron job in next version.
-				set_transient( $transient_name, $info, 1 * HOUR_IN_SECONDS );
-			}
-
-
-			/**
-			 * Check if field exists
-			 * Return value based on the field attribute
-			 */
-
-
-			// Sanitize field attribute
-			$field = sanitize_title( $atts['field'] );
-
-
-			if ( $field == "downloaded" ) {
-	            return $info->downloaded;
-	        }
-
-			if ( $field == "name" ) {
-	            return $info->name;
-	        }
-
-			if ( $field == "slug" ) {
-	            return $info->slug;
-	        }
-
-			if ( $field == "version" ) {
-	            return $info->version;
-	        }
-
-			if ( $field == "author" ) {
-	            return $info->author;
-	        }
-
-			if ( $field == "author_profile" ) {
-	            return $info->author_profile;
-	        }
-
-			if ( $field == "last_updated" ) {
-	            return $info->last_updated;
-	        }
-
-			if ( $field == "download_link" ) {
-	            return $info->download_link;
-	        }
-
-			if ( $field == "requires" ) {
-				return $info->requires;
-			}
-
-			if ( $field == "tested" ) {
-				return $info->tested;
-			}
-
-            /**
-             * rating outputs a percentage, to get a number of stars like in the WP Plugin Repository, you need to divide the output by 20:
-             *
-             * $percentage = do_shortcode( '[mpi slug="' . $slug . '" field="rating"]' );
-             * $stars = $percentage / 20;
-             * printf( __( 'Rating: %s out of 5 stars', 'textdomain' ), $stars );
-             *
-             */
-            if ( $field == "rating" ) {
-                return $info->rating;
-            }
-
-		}
-
-
-	}
-
-	// create instance of class
-	global $my_plugin_information;
-	$my_plugin_information = new DOT_MyPluginInfo();
+// do nothing if class is already defined
+if( class_exists( 'DOT_MyPluginInfo' ) ) {
+	return;
 }
+
+// require includes
+require_once dirname( __FILE__ ) . '/includes/class-my-plugin-info.php';
+require_once dirname( __FILE__ ) . '/includes/functions.php';
+
+// create instance of plugin class
+global $my_plugin_information;
+$my_plugin_information = new DOT_MyPluginInfo();
+$my_plugin_information->add_hooks();


### PR DESCRIPTION
This code removes a lot of the unneeded `if` statements and adds two template functions.

```php
function mpi_get_plugin_info( $slug );
function mpi_get_plugin_field( $slug, $field );
```

Moved around the files a bit to maintain a clean overview. Hope you like it!